### PR TITLE
Add CDI Operator

### DIFF
--- a/deploy/kubevirt/base/kustomization.yaml
+++ b/deploy/kubevirt/base/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
 #  - namespace.yaml
   - https://github.com/kubevirt/kubevirt/releases/download/v1.3.0/kubevirt-operator.yaml
   - https://github.com/kubevirt/kubevirt/releases/download/v1.3.0/kubevirt-cr.yaml
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.59.0/cdi-operator.yaml
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.59.0/cdi-cr.yaml
 
 patches:
 - patch: |-


### PR DESCRIPTION
Containerized-Data-Importer (CDI) is a persistent storage management add-on for Kubernetes. It's primary goal is to provide a declarative way to build Virtual Machine Disks on PVCs for [Kubevirt](https://github.com/kubevirt/kubevirt) VMs

https://github.com/kubevirt/containerized-data-importer