### PR TITLE
chore: migrate Renovate config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary

This updates the Renovate preset from the deprecated `config:base` preset to `config:recommended`.

Renovate's Dependency Dashboard currently reports **Config Migration Needed** in #157, and this is the smallest public-config-only migration to clear that warning.

## Validation

- Ran `python3 -m json.tool renovate.json`
- Changed only `renovate.json`

This intentionally does not touch any registry/package lookup warnings, deployment settings, credentials, or dependency versions.
